### PR TITLE
Move gbs directory to project root

### DIFF
--- a/gbs/.gitignore
+++ b/gbs/.gitignore
@@ -1,0 +1,25 @@
+# === Build output ===
+build/
+obj/
+gbs_program
+compile_commands.json
+
+# === Editor / Dev tools ===
+.cache/
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# === Build Folder ===
+build/
+
+# === CMake cache ===
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile.back
+
+# === Misc ===
+*.log
+

--- a/gbs/CMakeLists.txt
+++ b/gbs/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.16)
+project(gbs LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+add_subdirectory(../external/RF24 external/RF24)
+
+file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
+    ${CMAKE_SOURCE_DIR}/src/*.cpp
+)
+
+add_executable(gbs_program ${SRC_FILES})
+
+target_include_directories(gbs_program PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ../external/RF24
+)
+
+target_link_libraries(gbs_program PRIVATE rf24)
+
+add_custom_command(TARGET gbs_program POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+            ${CMAKE_BINARY_DIR}/compile_commands.json
+            ${CMAKE_SOURCE_DIR}/compile_commands.json)
+
+add_custom_target(run COMMAND gbs_program DEPENDS gbs_program
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/gbs/README.md
+++ b/gbs/README.md
@@ -1,0 +1,7 @@
+# gbs
+
+Ground base station sample using a copy of headers from the
+`rf24drone` project. It demonstrates handling of join requests,
+telemetry packets and command broadcasting using the same folder
+layout as the drone library. The code lives in the top level `gbs`
+directory with the usual `include/` and `src/` subdirectories.

--- a/gbs/include/gbs.hpp
+++ b/gbs/include/gbs.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "packets.hpp"
+#include "radio.hpp"
+#include <string>
+#include <vector>
+
+struct GroundDroneInfo {
+  DroneIdType id{};
+  std::string name;
+  float last_link_quality = 0.0f;
+};
+
+class GroundBaseStation {
+public:
+  explicit GroundBaseStation(RadioInterface &radio);
+
+  void handleIncoming();
+  void broadcastCommand(const std::string &cmd);
+  const std::vector<GroundDroneInfo> &getDrones() const { return drones_; }
+
+private:
+  RadioInterface &radio_;
+  std::vector<GroundDroneInfo> drones_;
+
+  void processJoinRequest(const JoinRequestPacket &req);
+  void processTelemetry(const TelemetryPacket &tel);
+};

--- a/gbs/include/packets.hpp
+++ b/gbs/include/packets.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+using DroneIdType = uint8_t;
+// ==================== Packet Types ==================== //
+
+enum class PacketType : uint8_t {
+  UNDEFINED = 0,
+  JOIN_REQUEST = 1,
+  JOIN_RESPONSE = 2,
+  COMMAND = 3,
+  TELEMETRY = 4,
+  HEARTBEAT = 5,
+  LEADER_ANNOUNCEMENT = 6,
+  PERMISSION_TO_SEND = 7,
+  LEADER_REQUEST = 8,
+};
+// ==================== Constants ==================== //
+
+constexpr size_t MAX_COMMAND_LENGTH = 20;
+constexpr size_t MAX_NODE_NAME_LENGTH = 20;
+
+// ==================== Packet Structures ==================== //
+
+#pragma pack(push, 1)
+struct CommandPacket {
+  PacketType type = PacketType::COMMAND;
+  DroneIdType target_drone_id;
+  uint32_t timestamp;
+  char command[MAX_COMMAND_LENGTH];
+};
+
+struct TelemetryPacket {
+  PacketType type = PacketType::TELEMETRY;
+  DroneIdType drone_id;
+  uint32_t timestamp;
+  int16_t acceleration_x, acceleration_y, acceleration_z;
+  int16_t gyroscope_x, gyroscope_y, gyroscope_z;
+  float battery_voltage;
+  float altitude;
+  uint8_t rpd;
+  uint8_t retries;
+  float link_quality;
+};
+
+struct JoinRequestPacket {
+  PacketType type = PacketType::JOIN_REQUEST;
+  uint32_t timestamp;
+  DroneIdType temp_id;
+  char requested_name[MAX_NODE_NAME_LENGTH];
+};
+
+struct JoinResponsePacket {
+  PacketType type = PacketType::JOIN_RESPONSE;
+  DroneIdType assigned_id;
+  DroneIdType current_leader_id;
+  uint8_t assigned_channel;
+  uint32_t timestamp;
+};
+
+struct HeartbeatPacket {
+  PacketType type = PacketType::HEARTBEAT;
+  DroneIdType source_drone_id;
+  uint32_t timestamp;
+};
+
+struct LeaderAnnouncementPacket {
+  PacketType type = PacketType::LEADER_ANNOUNCEMENT;
+  DroneIdType new_leader_id;
+  uint32_t timestamp;
+};
+
+struct PermissionToSendPacket {
+  PacketType type = PacketType::PERMISSION_TO_SEND;
+  DroneIdType target_drone_id;
+  uint32_t timestamp;
+};
+
+struct LeaderRequestPacket {
+  PacketType type = PacketType::LEADER_REQUEST;
+  DroneIdType drone_id;
+  uint32_t timestamp;
+};
+#pragma pack(pop)
+
+// ==================== Assertions for Packet Sizes ==================== //
+static_assert(sizeof(LeaderAnnouncementPacket) == 6,
+              "LeaderAnnouncementPacket size mismatch");
+
+static_assert(sizeof(HeartbeatPacket) == 6, "HeartbeatPacket size mismatch");
+
+static_assert(sizeof(JoinResponsePacket) == 8,
+              "JoinResponsePacket boyutu hatalı");
+
+static_assert(sizeof(JoinRequestPacket) == 26,
+              "JoinRequestPacket boyutu hatalı");
+
+static_assert(sizeof(TelemetryPacket) == 32, "TelemetryPacket size mismatch");
+
+static_assert(sizeof(CommandPacket) == 26, "CommandPacket size mismatch");
+
+static_assert(sizeof(PermissionToSendPacket) == 6,
+              "PermissionToSendPacket size mismatch");
+
+static_assert(sizeof(LeaderRequestPacket) == 6,
+              "LeaderRequestPacket size mismatch");

--- a/gbs/include/radio.hpp
+++ b/gbs/include/radio.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "packets.hpp"
+#include <RF24.h>
+#include <array>
+#include <cstdint>
+#include <optional>
+
+enum class RadioDataRate {
+  LOW_RATE,
+  MEDIUM_RATE,
+  HIGH_RATE,
+};
+
+class RadioInterface {
+public:
+  RadioInterface(uint8_t cePin, uint8_t csnPin); // for default SPI BUS
+  RadioInterface(uint8_t cePin, uint8_t csnPin,
+                 uint8_t spiPort); // for custom SPI BUS
+
+  bool begin();
+  void setAddress(uint64_t tx, uint64_t rx);
+  void openListeningPipe(uint8_t pipe, uint64_t address);
+  void configure(uint8_t channel = 90,
+                 RadioDataRate datarate = RadioDataRate::MEDIUM_RATE);
+
+  bool send(const void *data, size_t size);
+  bool receive(void *data, size_t size, bool peekOnly = false);
+
+  bool testRPD();
+  uint8_t getARC();
+
+private:
+  RF24 radio;
+  uint64_t tx_address = 0;
+  uint64_t rx_address = 0;
+  // Holds the latest packet when it was peeked so that it can be
+  // retrieved again on the next receive call.
+  std::optional<std::array<uint8_t, 32>> cached_packet;
+};

--- a/gbs/src/gbs.cpp
+++ b/gbs/src/gbs.cpp
@@ -1,0 +1,72 @@
+#include "../include/gbs.hpp"
+#include <array>
+#include <cstring>
+#include <ctime>
+#include <iostream>
+
+GroundBaseStation::GroundBaseStation(RadioInterface &radio) : radio_(radio) {}
+
+void GroundBaseStation::processJoinRequest(const JoinRequestPacket &req) {
+  GroundDroneInfo info{};
+  info.id = static_cast<DroneIdType>(drones_.size() + 1);
+  info.name = req.requested_name;
+  drones_.push_back(info);
+
+  JoinResponsePacket resp{};
+  resp.assigned_id = info.id;
+  resp.current_leader_id = info.id; // first joiner becomes leader
+  resp.assigned_channel = 2;        // fixed channel for demo
+  resp.timestamp = static_cast<uint32_t>(std::time(nullptr));
+
+  radio_.send(&resp, sizeof(resp));
+  std::cout << "JoinRequest from " << info.name
+            << " assigned ID " << static_cast<int>(info.id) << std::endl;
+}
+
+void GroundBaseStation::processTelemetry(const TelemetryPacket &tel) {
+  for (auto &d : drones_) {
+    if (d.id == tel.drone_id) {
+      d.last_link_quality = tel.link_quality;
+      std::cout << "Telemetry from " << d.name
+                << " LQ=" << tel.link_quality << std::endl;
+      return;
+    }
+  }
+}
+
+void GroundBaseStation::handleIncoming() {
+  PacketType peek;
+  while (radio_.receive(&peek, sizeof(PacketType), true)) {
+    switch (peek) {
+    case PacketType::JOIN_REQUEST: {
+      JoinRequestPacket req{};
+      if (radio_.receive(&req, sizeof(req)))
+        processJoinRequest(req);
+      break;
+    }
+    case PacketType::TELEMETRY: {
+      TelemetryPacket tel{};
+      if (radio_.receive(&tel, sizeof(tel)))
+        processTelemetry(tel);
+      break;
+    }
+    default: {
+      std::array<uint8_t, 32> dummy{};
+      radio_.receive(dummy.data(), dummy.size());
+      break;
+    }
+    }
+  }
+}
+
+void GroundBaseStation::broadcastCommand(const std::string &cmd) {
+  CommandPacket packet{};
+  packet.timestamp = static_cast<uint32_t>(std::time(nullptr));
+  std::strncpy(packet.command, cmd.c_str(), MAX_COMMAND_LENGTH - 1);
+  packet.command[MAX_COMMAND_LENGTH - 1] = '\0';
+
+  for (const auto &d : drones_) {
+    packet.target_drone_id = d.id;
+    radio_.send(&packet, sizeof(packet));
+  }
+}

--- a/gbs/src/main.cpp
+++ b/gbs/src/main.cpp
@@ -1,0 +1,28 @@
+#include "gbs.hpp"
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#define CE_PIN 27
+#define CSN_PIN 10
+
+static constexpr uint64_t BASE_TX = 0xF0F0F0F0E1LL;
+static constexpr uint64_t BASE_RX = 0xF0F0F0F0D2LL;
+
+int main() {
+  RadioInterface radio(CE_PIN, CSN_PIN);
+  if (!radio.begin()) {
+    std::cerr << "Radio init failed" << std::endl;
+    return 1;
+  }
+
+  radio.configure(1, RadioDataRate::MEDIUM_RATE);
+  radio.setAddress(BASE_TX, BASE_RX);
+
+  GroundBaseStation gbs(radio);
+
+  while (true) {
+    gbs.handleIncoming();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+}

--- a/gbs/src/radio.cpp
+++ b/gbs/src/radio.cpp
@@ -1,0 +1,96 @@
+#include "../include/radio.hpp"
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+
+RadioInterface::RadioInterface(uint8_t cePin, uint8_t csnPin)
+    : radio(cePin, csnPin) {}
+
+RadioInterface::RadioInterface(uint8_t cePin, uint8_t csnPin, uint8_t spiPort)
+    : radio(cePin, csnPin, spiPort) {}
+
+bool RadioInterface::begin() {
+  if (!radio.begin())
+    return false;
+  radio.setPALevel(RF24_PA_LOW);
+  radio.stopListening();
+  return true;
+}
+
+void RadioInterface::setAddress(uint64_t tx, uint64_t rx) {
+  tx_address = tx;
+  rx_address = rx;
+  radio.openWritingPipe(tx_address);
+  radio.openReadingPipe(1, rx_address);
+}
+
+void RadioInterface::openListeningPipe(uint8_t pipe, uint64_t address) {
+  radio.openReadingPipe(pipe, address);
+}
+
+void RadioInterface::configure(uint8_t channel, RadioDataRate datarate) {
+  radio.setChannel(channel);
+  switch (datarate) {
+  case RadioDataRate::LOW_RATE:
+    radio.setDataRate(RF24_250KBPS);
+    break;
+  case RadioDataRate::MEDIUM_RATE:
+    radio.setDataRate(RF24_1MBPS);
+    break;
+  case RadioDataRate::HIGH_RATE:
+    radio.setDataRate(RF24_2MBPS);
+    break;
+  }
+  radio.setAutoAck(true);
+  radio.enableDynamicPayloads();
+  radio.enableAckPayload();
+  radio.startListening();
+}
+
+bool RadioInterface::send(const void *data, size_t size) {
+  radio.stopListening();
+  bool success = radio.write(data, static_cast<uint8_t>(size));
+  radio.startListening();
+  return success;
+}
+
+bool RadioInterface::receive(void *data, size_t size, bool peekOnly) {
+  if (peekOnly) {
+    if (cached_packet) {
+      std::memcpy(data, cached_packet->data(), size);
+      return true;
+    }
+
+    if (!radio.available())
+      return false;
+
+    cached_packet.emplace();
+    radio.read(cached_packet->data(),
+               static_cast<uint8_t>(cached_packet->size()));
+    std::memcpy(data, cached_packet->data(), size);
+    return true;
+  }
+
+  if (cached_packet) {
+    std::memcpy(data, cached_packet->data(), size);
+    cached_packet.reset();
+    return true;
+  }
+
+  if (!radio.available())
+    return false;
+
+  std::array<uint8_t, 32> buffer{};
+  radio.read(buffer.data(), buffer.size());
+  std::memcpy(data, buffer.data(), size);
+  cached_packet.reset();
+  return true;
+}
+
+bool RadioInterface::testRPD() {
+  return radio.testRPD();
+}
+
+uint8_t RadioInterface::getARC() {
+  return radio.getARC();
+}


### PR DESCRIPTION
## Summary
- relocate the `gbs` library so it sits beside `lib` instead of inside it
- update the gbs build script to use new relative paths
- clarify in README that gbs lives at the project root

## Testing
- `g++ -std=c++20 -I gbs/include -I external/RF24 -I external/RF24/utility -I external/RF24/utility/RPi -c gbs/src/gbs.cpp`
- `g++ -std=c++20 -I gbs/include -I external/RF24 -I external/RF24/utility -I external/RF24/utility/RPi -c gbs/src/radio.cpp`
- `g++ -std=c++20 -I gbs/include -I external/RF24 -I external/RF24/utility -I external/RF24/utility/RPi -c gbs/src/main.cpp`
- `g++ -std=c++20 -I gbs/include -I external/RF24 -I external/RF24/utility -I external/RF24/utility/RPi gbs/src/*.cpp external/RF24/RF24.cpp external/RF24/utility/RPi/*.cpp -o /tmp/gbs_program` *(fails: undefined reference to `bcm2835_*`)*


------
https://chatgpt.com/codex/tasks/task_e_6841dcdf9d508326a42fbe9da903bfda