### PR TITLE
Modify GBS to request manual commands

### DIFF
--- a/include/gbs.hpp
+++ b/include/gbs.hpp
@@ -2,6 +2,7 @@
 
 #include "packets.hpp"
 #include "radio.hpp"
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -17,11 +18,14 @@ public:
 
   void handleIncoming();
   void broadcastCommand(const std::string &cmd);
+  void sendCommandToDrone(DroneIdType id, const std::string &cmd);
+  std::vector<GroundDroneInfo> getDronesSnapshot() const;
   const std::vector<GroundDroneInfo> &getDrones() const { return drones_; }
 
 private:
   RadioInterface &radio_;
   std::vector<GroundDroneInfo> drones_;
+  mutable std::mutex drones_mutex_;
 
   void processJoinRequest(const JoinRequestPacket &req);
   void processTelemetry(const TelemetryPacket &tel);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,11 @@
 #include "gbs.hpp"
 #include <chrono>
 #include <iostream>
+#include <mutex>
+#include <queue>
+#include <string>
 #include <thread>
+#include <utility>
 
 #define CE_PIN 27
 #define CSN_PIN 10
@@ -21,8 +25,49 @@ int main() {
 
   GroundBaseStation gbs(radio);
 
+  std::mutex cmd_mutex;
+  std::queue<std::pair<DroneIdType, std::string>> cmd_queue;
+
+  std::thread input_thread([&]() {
+    while (true) {
+      auto drones = gbs.getDronesSnapshot();
+      std::cout << "\nConnected drones:" << std::endl;
+      for (const auto &d : drones) {
+        std::cout << "  ID " << static_cast<int>(d.id) << " - " << d.name
+                  << std::endl;
+      }
+      std::cout << "Enter target drone id (0=all, empty to skip): ";
+      std::string id_line;
+      if (!std::getline(std::cin, id_line))
+        break;
+      if (id_line.empty())
+        continue;
+      DroneIdType id = static_cast<DroneIdType>(std::stoi(id_line));
+      std::cout << "Enter command: ";
+      std::string cmd;
+      if (!std::getline(std::cin, cmd))
+        break;
+      if (cmd.empty())
+        continue;
+      std::lock_guard<std::mutex> lock(cmd_mutex);
+      cmd_queue.emplace(id, cmd);
+    }
+  });
+  input_thread.detach();
+
   while (true) {
     gbs.handleIncoming();
+    {
+      std::lock_guard<std::mutex> lock(cmd_mutex);
+      if (!cmd_queue.empty()) {
+        auto [id, cmd] = cmd_queue.front();
+        cmd_queue.pop();
+        if (id == 0)
+          gbs.broadcastCommand(cmd);
+        else
+          gbs.sendCommandToDrone(id, cmd);
+      }
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 }


### PR DESCRIPTION
## Summary
- add functions in `GroundBaseStation` to send a command to a single drone and to snapshot the drone list
- protect drone data with a mutex
- rework main input thread to choose target drone ID before entering a command

## Testing
- `cmake ..` (from `build/`)
- `make -j$(nproc)`
- `./gbs_program` *(fails: Can't open device /dev/spidev1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68443486c5888326a963e4999c19e654