### PR TITLE
Support dual radios for GBS

### DIFF
--- a/include/gbs.hpp
+++ b/include/gbs.hpp
@@ -14,7 +14,8 @@ struct GroundDroneInfo {
 
 class GroundBaseStation {
 public:
-  explicit GroundBaseStation(RadioInterface &radio);
+  explicit GroundBaseStation(RadioInterface &radio); // use one radio for both TX and RX
+  GroundBaseStation(RadioInterface &rx_radio, RadioInterface &tx_radio);
 
   void handleIncoming();
   void broadcastCommand(const std::string &cmd);
@@ -23,7 +24,8 @@ public:
   const std::vector<GroundDroneInfo> &getDrones() const { return drones_; }
 
 private:
-  RadioInterface &radio_;
+  RadioInterface &rx_radio_;
+  RadioInterface &tx_radio_;
   std::vector<GroundDroneInfo> drones_;
   mutable std::mutex drones_mutex_;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,23 +7,29 @@
 #include <thread>
 #include <utility>
 
-#define CE_PIN 27
-#define CSN_PIN 10
+#define TX_CE_PIN 27
+#define TX_CSN_PIN 10
+#define RX_CE_PIN 22
+#define RX_CSN_PIN 0
 
 static constexpr uint64_t BASE_TX = 0xF0F0F0F0E1LL;
 static constexpr uint64_t BASE_RX = 0xF0F0F0F0D2LL;
 
 int main() {
-  RadioInterface radio(CE_PIN, CSN_PIN);
-  if (!radio.begin()) {
+  RadioInterface txRadio(TX_CE_PIN, TX_CSN_PIN);
+  RadioInterface rxRadio(RX_CE_PIN, RX_CSN_PIN);
+
+  if (!txRadio.begin() || !rxRadio.begin()) {
     std::cerr << "Radio init failed" << std::endl;
     return 1;
   }
 
-  radio.configure(1, RadioDataRate::MEDIUM_RATE);
-  radio.setAddress(BASE_TX, BASE_RX);
+  txRadio.configure(1, RadioDataRate::MEDIUM_RATE);
+  rxRadio.configure(1, RadioDataRate::MEDIUM_RATE);
+  txRadio.setAddress(BASE_TX, BASE_RX);
+  rxRadio.setAddress(BASE_TX, BASE_RX);
 
-  GroundBaseStation gbs(radio);
+  GroundBaseStation gbs(rxRadio, txRadio);
 
   std::mutex cmd_mutex;
   std::queue<std::pair<DroneIdType, std::string>> cmd_queue;


### PR DESCRIPTION
## Summary
- allow GroundBaseStation to operate with separate RX/TX NRF24 modules
- update main program to initialize dedicated RX and TX radios

## Testing
- `cmake ..`
- `cmake --build .`
- `./gbs_program` *(fails: Can't open device /dev/spidev1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68443815785c8326acae5c2ea514f3ec