### PR TITLE
Add basic Qt GUI for gbs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,21 +4,40 @@ project(gbs LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/external/RF24 external/RF24)
 
-file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
-    ${CMAKE_SOURCE_DIR}/src/*.cpp
+find_package(Qt5 REQUIRED COMPONENTS Widgets)
+
+set(CLI_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/gbs.cpp
+    ${CMAKE_SOURCE_DIR}/src/radio.cpp
+    ${CMAKE_SOURCE_DIR}/src/main.cpp
 )
 
-add_executable(gbs_program ${SRC_FILES})
+set(GUI_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/gbs.cpp
+    ${CMAKE_SOURCE_DIR}/src/radio.cpp
+    ${CMAKE_SOURCE_DIR}/src/gui_main.cpp
+)
+
+add_executable(gbs_program ${CLI_SOURCES})
+add_executable(gbs_gui ${GUI_SOURCES})
 
 target_include_directories(gbs_program PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/external/RF24
 )
+target_include_directories(gbs_gui PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/external/RF24
+)
 
 target_link_libraries(gbs_program PRIVATE rf24)
+target_link_libraries(gbs_gui PRIVATE rf24 Qt5::Widgets)
 
 add_custom_command(TARGET gbs_program POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E create_symlink
@@ -26,4 +45,7 @@ add_custom_command(TARGET gbs_program POST_BUILD
             ${CMAKE_SOURCE_DIR}/compile_commands.json)
 
 add_custom_target(run COMMAND gbs_program DEPENDS gbs_program
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_custom_target(run_gui COMMAND gbs_gui DEPENDS gbs_gui
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/src/gui_main.cpp
+++ b/src/gui_main.cpp
@@ -1,0 +1,115 @@
+#include <QApplication>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QListWidget>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QLabel>
+#include <QTextEdit>
+#include <QTimer>
+
+#include "gbs.hpp"
+
+class GbsWindow : public QWidget {
+    Q_OBJECT
+public:
+    GbsWindow(GroundBaseStation &station, QWidget *parent = nullptr)
+        : QWidget(parent), station_(station) {
+        droneList_ = new QListWidget(this);
+        lastCommandLabel_ = new QLabel("Last Command: none", this);
+        logArea_ = new QTextEdit(this);
+        logArea_->setReadOnly(true);
+        commandEdit_ = new QLineEdit(this);
+        QPushButton *sendBtn = new QPushButton("Send", this);
+
+        QHBoxLayout *cmdLayout = new QHBoxLayout;
+        cmdLayout->addWidget(commandEdit_);
+        cmdLayout->addWidget(sendBtn);
+
+        QVBoxLayout *layout = new QVBoxLayout;
+        layout->addWidget(new QLabel("Connected Drones:"));
+        layout->addWidget(droneList_);
+        layout->addWidget(lastCommandLabel_);
+        layout->addLayout(cmdLayout);
+        layout->addWidget(new QLabel("Messages:"));
+        layout->addWidget(logArea_);
+        setLayout(layout);
+
+        connect(sendBtn, &QPushButton::clicked, this, &GbsWindow::sendCommand);
+
+        QTimer *timer = new QTimer(this);
+        connect(timer, &QTimer::timeout, this, &GbsWindow::updateDrones);
+        timer->start(1000);
+    }
+
+private slots:
+    void updateDrones() {
+        station_.handleIncoming();
+        droneList_->clear();
+        for (const auto &d : station_.getDronesSnapshot()) {
+            droneList_->addItem(QString("%1 (id %2)")
+                                    .arg(QString::fromStdString(d.name))
+                                    .arg(d.id));
+        }
+    }
+
+    void sendCommand() {
+        QString cmd = commandEdit_->text();
+        if (cmd.isEmpty())
+            return;
+        QListWidgetItem *current = droneList_->currentItem();
+        DroneIdType id = 0;
+        if (current) {
+            // extract id from text 'name (id X)'
+            QString text = current->text();
+            int idx = text.lastIndexOf("id ");
+            if (idx != -1)
+                id = static_cast<DroneIdType>(text.mid(idx + 3).toInt());
+        }
+        std::string cmdStr = cmd.toStdString();
+        if (id == 0)
+            station_.broadcastCommand(cmdStr);
+        else
+            station_.sendCommandToDrone(id, cmdStr);
+        lastCommandLabel_->setText(QString("Last Command: %1 -> %2")
+                                       .arg(id)
+                                       .arg(cmd));
+        logArea_->append(lastCommandLabel_->text());
+        commandEdit_->clear();
+    }
+
+private:
+    GroundBaseStation &station_;
+    QListWidget *droneList_;
+    QLabel *lastCommandLabel_;
+    QTextEdit *logArea_;
+    QLineEdit *commandEdit_;
+};
+
+
+int main(int argc, char **argv) {
+    QApplication app(argc, argv);
+
+    RadioInterface txRadio(27, 10);
+    RadioInterface rxRadio(22, 0);
+
+    if (!txRadio.begin() || !rxRadio.begin()) {
+        qCritical("Radio init failed");
+        return 1;
+    }
+
+    txRadio.configure(1, RadioDataRate::MEDIUM_RATE);
+    rxRadio.configure(1, RadioDataRate::MEDIUM_RATE);
+    txRadio.setAddress(0xF0F0F0F0E1LL, 0xF0F0F0F0D2LL);
+    rxRadio.setAddress(0xF0F0F0F0E1LL, 0xF0F0F0F0D2LL);
+
+    GroundBaseStation station(rxRadio, txRadio);
+
+    GbsWindow window(station);
+    window.resize(500, 400);
+    window.show();
+
+    return app.exec();
+}
+
+#include "gui_main.moc"


### PR DESCRIPTION
## Summary
- add a Qt based GUI that lists connected drones and allows sending commands
- support Qt build in CMake and create a `gbs_gui` target

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68443d4d1a6c8326b01a0c76082e7704