### PR TITLE
Add headless telemetry test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,10 @@ set(CMAKE_AUTOUIC ON)
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/external/RF24 external/RF24)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+option(BUILD_GUI "Build GUI application" OFF)
+if(BUILD_GUI)
+    find_package(Qt5 REQUIRED COMPONENTS Widgets)
+endif()
 
 set(CLI_SOURCES
     ${CMAKE_SOURCE_DIR}/src/gbs.cpp
@@ -25,19 +28,36 @@ set(GUI_SOURCES
 )
 
 add_executable(gbs_program ${CLI_SOURCES})
-add_executable(gbs_gui ${GUI_SOURCES})
+if(BUILD_GUI)
+    add_executable(gbs_gui ${GUI_SOURCES})
+endif()
 
 target_include_directories(gbs_program PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/external/RF24
 )
-target_include_directories(gbs_gui PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/external/RF24
-)
+if(BUILD_GUI)
+    target_include_directories(gbs_gui PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_SOURCE_DIR}/external/RF24
+    )
+endif()
 
 target_link_libraries(gbs_program PRIVATE rf24)
-target_link_libraries(gbs_gui PRIVATE rf24 Qt5::Widgets)
+if(BUILD_GUI)
+    target_link_libraries(gbs_gui PRIVATE rf24 Qt5::Widgets)
+endif()
+
+# Simple test to receive telemetry (MPU) data without GUI
+add_executable(mpu_receive_test
+    ${CMAKE_SOURCE_DIR}/tests/mpu_receive_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/radio.cpp)
+
+target_include_directories(mpu_receive_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/external/RF24)
+
+target_link_libraries(mpu_receive_test PRIVATE rf24)
 
 add_custom_command(TARGET gbs_program POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E create_symlink
@@ -47,5 +67,7 @@ add_custom_command(TARGET gbs_program POST_BUILD
 add_custom_target(run COMMAND gbs_program DEPENDS gbs_program
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-add_custom_target(run_gui COMMAND gbs_gui DEPENDS gbs_gui
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+if(BUILD_GUI)
+    add_custom_target(run_gui COMMAND gbs_gui DEPENDS gbs_gui
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endif()

--- a/tests/mpu_receive_test.cpp
+++ b/tests/mpu_receive_test.cpp
@@ -1,0 +1,41 @@
+#include "radio.hpp"
+#include "packets.hpp"
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#define RX_CE_PIN 22
+#define RX_CSN_PIN 10
+
+static constexpr uint64_t BASE_TX = 0xF0F0F0F0E1LL;
+static constexpr uint64_t BASE_RX = 0xF0F0F0F0D2LL;
+
+int main() {
+    RadioInterface radio(RX_CE_PIN, RX_CSN_PIN);
+    if (!radio.begin()) {
+        std::cerr << "Radio init failed" << std::endl;
+        return 1;
+    }
+
+    radio.configure(1, RadioDataRate::MEDIUM_RATE);
+    radio.setAddress(BASE_TX, BASE_RX);
+
+    std::cout << "Waiting for telemetry packets..." << std::endl;
+    while (true) {
+        PacketType type;
+        if (radio.receive(&type, sizeof(type), true) && type == PacketType::TELEMETRY) {
+            TelemetryPacket packet{};
+            if (radio.receive(&packet, sizeof(packet))) {
+                std::cout << "Accel: " << packet.acceleration_x << ',' << packet.acceleration_y
+                          << ',' << packet.acceleration_z
+                          << " Gyro: " << packet.gyroscope_x << ',' << packet.gyroscope_y
+                          << ',' << packet.gyroscope_z
+                          << " Altitude: " << packet.altitude
+                          << " Battery: " << packet.battery_voltage
+                          << std::endl;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- make Qt optional for CLI builds
- add a simple headless test to receive telemetry data from the drone
- build `mpu_receive_test` with CMake

## Testing
- `cmake -DBUILD_GUI=OFF ..`
- `cmake --build . --target mpu_receive_test`

------
https://chatgpt.com/codex/tasks/task_e_6856c3ac9a248326b4566504e3f78f5c