### PR TITLE
Add simple gyro server example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,3 +71,14 @@ if(BUILD_GUI)
     add_custom_target(run_gui COMMAND gbs_gui DEPENDS gbs_gui
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 endif()
+
+# Simple server to read gyro data from SimplePacket drones
+add_executable(gyro_server
+    ${CMAKE_SOURCE_DIR}/src/gyro_server.cpp
+    ${CMAKE_SOURCE_DIR}/src/radio.cpp)
+
+target_include_directories(gyro_server PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/external/RF24)
+
+target_link_libraries(gyro_server PRIVATE rf24)

--- a/src/gyro_server.cpp
+++ b/src/gyro_server.cpp
@@ -1,0 +1,43 @@
+#include "radio.hpp"
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#define RX_CE_PIN 22
+#define RX_CSN_PIN 10
+static constexpr uint64_t BASE_TX = 0xF0F0F0F0E1ULL;
+static constexpr uint64_t BASE_RX = 0xF0F0F0F0D2ULL;
+
+struct SimplePacket {
+    uint8_t drone_id;
+    int16_t gyro_x;
+    int16_t gyro_y;
+    int16_t gyro_z;
+    bool leader;
+};
+
+int main() {
+    RadioInterface radio(RX_CE_PIN, RX_CSN_PIN);
+    if (!radio.begin()) {
+        std::cerr << "Radio init failed" << std::endl;
+        return 1;
+    }
+
+    radio.configure(1, RadioDataRate::MEDIUM_RATE);
+    radio.setAddress(BASE_TX, BASE_RX);
+
+    std::cout << "Listening for packets..." << std::endl;
+    while (true) {
+        SimplePacket pkt{};
+        if (radio.receive(&pkt, sizeof(pkt))) {
+            std::cout << "ID " << static_cast<int>(pkt.drone_id)
+                      << " Gyro: " << pkt.gyro_x << ',' << pkt.gyro_y << ','
+                      << pkt.gyro_z
+                      << " Leader: " << std::boolalpha << pkt.leader
+                      << std::endl;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement `gyro_server` program to log incoming gyro data by drone ID
- update `CMakeLists.txt` to build the new example

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685722ebf3ec83268674cec69583afd1