### PR TITLE
Add ARC reporting in gyro_server

### DIFF
--- a/src/gyro_server.cpp
+++ b/src/gyro_server.cpp
@@ -107,8 +107,10 @@ int main() {
         char msg[32]{};
         std::snprintf(msg, sizeof(msg), "%u Leader = True", current_leader);
         txRadio.send(msg, sizeof(msg));
+        uint8_t arc = txRadio.getARC();
 
         std::cout << "New leader: " << static_cast<int>(current_leader)
+                  << " ARC: " << static_cast<int>(arc)
                   << std::endl;
       } else {
         std::cout << "No leader" << std::endl;


### PR DESCRIPTION
## Summary
- add ARC output after sending the leader message in `gyro_server`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6857445f04008326a105ea86285b14af