### PR TITLE
Convert raw gyro data to physical units

### DIFF
--- a/include/sensor_utils.hpp
+++ b/include/sensor_utils.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <cstdint>
+
+inline float accelRawToMs2(int16_t raw) {
+    // Convert raw accelerometer reading to m/s^2
+    return static_cast<float>(raw) / 16384.0f * 9.81f;
+}
+
+inline float gyroRawToDps(int16_t raw) {
+    // Convert raw gyro reading to degrees/s
+    return static_cast<float>(raw) / 131.0f;
+}

--- a/src/gyro_server.cpp
+++ b/src/gyro_server.cpp
@@ -1,4 +1,5 @@
 #include "radio.hpp"
+#include "sensor_utils.hpp"
 #include <algorithm>
 #include <chrono>
 #include <iostream>
@@ -70,12 +71,20 @@ int main() {
       data.last_update = std::chrono::steady_clock::now();
       data.online = true;
 
+      float ax = accelRawToMs2(pkt.accel_x);
+      float ay = accelRawToMs2(pkt.accel_y);
+      float az = accelRawToMs2(pkt.accel_z);
+      float gx = gyroRawToDps(pkt.gyro_x);
+      float gy = gyroRawToDps(pkt.gyro_y);
+      float gz = gyroRawToDps(pkt.gyro_z);
+
       std::cout << "ID " << static_cast<int>(pkt.drone_id)
                 << " Accel: " << pkt.accel_x << ',' << pkt.accel_y << ','
-                << pkt.accel_z << " Gyro: " << pkt.gyro_x << ',' << pkt.gyro_y
-                << ',' << pkt.gyro_z << " Leader: " << std::boolalpha
-                << pkt.leader << " RSSI> -64: " << data.strong_signal
-                << std::endl;
+                << pkt.accel_z << " (" << ax << ',' << ay << ',' << az
+                << " m/s^2) Gyro: " << pkt.gyro_x << ',' << pkt.gyro_y
+                << ',' << pkt.gyro_z << " (" << gx << ',' << gy << ',' << gz
+                << " dps) Leader: " << std::boolalpha << pkt.leader
+                << " RSSI> -64: " << data.strong_signal << std::endl;
     }
 
     auto now = std::chrono::steady_clock::now();

--- a/tests/mpu_receive_test.cpp
+++ b/tests/mpu_receive_test.cpp
@@ -1,5 +1,6 @@
 #include "packets.hpp"
 #include "radio.hpp"
+#include "sensor_utils.hpp"
 #include <chrono>
 #include <iostream>
 #include <thread>
@@ -27,10 +28,19 @@ int main() {
         type == PacketType::TELEMETRY) {
       TelemetryPacket packet{};
       if (radio.receive(&packet, sizeof(packet))) {
+        float ax = accelRawToMs2(packet.acceleration_x);
+        float ay = accelRawToMs2(packet.acceleration_y);
+        float az = accelRawToMs2(packet.acceleration_z);
+        float gx = gyroRawToDps(packet.gyroscope_x);
+        float gy = gyroRawToDps(packet.gyroscope_y);
+        float gz = gyroRawToDps(packet.gyroscope_z);
+
         std::cout << "Accel: " << packet.acceleration_x << ','
                   << packet.acceleration_y << ',' << packet.acceleration_z
+                  << " (" << ax << ',' << ay << ',' << az << " m/s^2)"
                   << " Gyro: " << packet.gyroscope_x << ','
                   << packet.gyroscope_y << ',' << packet.gyroscope_z
+                  << " (" << gx << ',' << gy << ',' << gz << " dps)"
                   << " Altitude: " << packet.altitude
                   << " Battery: " << packet.battery_voltage << std::endl;
       }


### PR DESCRIPTION
## Summary
- add sensor utility helpers for scaling raw accelerometer and gyro readings
- use helpers when printing telemetry in `mpu_receive_test`
- also scale values when logging packets in `gyro_server`

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68574a7cb8088326b90dc08d9ea3165c