### PR TITLE
Implement leader election in ground station

### DIFF
--- a/include/gbs.hpp
+++ b/include/gbs.hpp
@@ -5,11 +5,14 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <chrono>
 
 struct GroundDroneInfo {
   DroneIdType id{};
   std::string name;
   float last_link_quality = 0.0f;
+  std::chrono::steady_clock::time_point last_update;
+  bool online = true;
 };
 
 class GroundBaseStation {
@@ -27,6 +30,8 @@ private:
   RadioInterface &rx_radio_;
   RadioInterface &tx_radio_;
   std::vector<GroundDroneInfo> drones_;
+  DroneIdType current_leader_ = 0;
+  bool have_leader_ = false;
   mutable std::mutex drones_mutex_;
 
   void processJoinRequest(const JoinRequestPacket &req);

--- a/src/gbs.cpp
+++ b/src/gbs.cpp
@@ -4,7 +4,10 @@
 #include <ctime>
 #include <iostream>
 #include <mutex>
+#include <chrono>
+#include <algorithm>
 
+static constexpr auto OFFLINE_TIMEOUT = std::chrono::seconds(2);
 GroundBaseStation::GroundBaseStation(RadioInterface &radio)
     : rx_radio_(radio), tx_radio_(radio) {}
 
@@ -17,7 +20,14 @@ void GroundBaseStation::processJoinRequest(const JoinRequestPacket &req) {
   GroundDroneInfo info{};
   info.id = static_cast<DroneIdType>(drones_.size() + 1);
   info.name = req.requested_name;
+  info.last_update = std::chrono::steady_clock::now();
+  info.online = true;
   drones_.push_back(info);
+
+  if (drones_.size() == 1) {
+    current_leader_ = info.id;
+    have_leader_ = true;
+  }
 
   JoinResponsePacket resp{};
   resp.assigned_id = info.id;
@@ -35,6 +45,11 @@ void GroundBaseStation::processTelemetry(const TelemetryPacket &tel) {
   for (auto &d : drones_) {
     if (d.id == tel.drone_id) {
       d.last_link_quality = tel.link_quality;
+      d.last_update = std::chrono::steady_clock::now();
+      if (!d.online) {
+        d.online = true;
+        std::cout << "Drone " << static_cast<int>(d.id) << " online" << std::endl;
+      }
       std::cout << "Telemetry from " << d.name
                 << " LQ=" << tel.link_quality << std::endl;
       return;
@@ -63,6 +78,58 @@ void GroundBaseStation::handleIncoming() {
       rx_radio_.receive(dummy.data(), dummy.size());
       break;
     }
+    }
+  }
+
+  auto now = std::chrono::steady_clock::now();
+  std::lock_guard<std::mutex> lock(drones_mutex_);
+
+  for (auto &d : drones_) {
+    bool is_online = now - d.last_update <= OFFLINE_TIMEOUT;
+    if (d.online != is_online) {
+      d.online = is_online;
+      std::cout << "Drone " << static_cast<int>(d.id)
+                << (is_online ? " online" : " offline") << std::endl;
+    }
+  }
+
+  if (have_leader_) {
+    auto it = std::find_if(drones_.begin(), drones_.end(),
+                           [&](const GroundDroneInfo &di) {
+                             return di.id == current_leader_;
+                           });
+    if (it == drones_.end() || !it->online) {
+      have_leader_ = false;
+    }
+  }
+
+  if (!have_leader_) {
+    bool found = false;
+    DroneIdType best_id = 0;
+    auto best_time = std::chrono::steady_clock::time_point::min();
+    for (const auto &d : drones_) {
+      if (!d.online)
+        continue;
+      if (!found || d.last_update > best_time) {
+        found = true;
+        best_id = d.id;
+        best_time = d.last_update;
+      }
+    }
+    if (found) {
+      current_leader_ = best_id;
+      have_leader_ = true;
+
+      LeaderAnnouncementPacket pkt{};
+      pkt.new_leader_id = current_leader_;
+      pkt.timestamp = static_cast<uint32_t>(std::time(nullptr));
+      tx_radio_.send(&pkt, sizeof(pkt));
+      uint8_t arc = tx_radio_.getARC();
+
+      std::cout << "New leader: " << static_cast<int>(current_leader_)
+                << " ARC: " << static_cast<int>(arc) << std::endl;
+    } else {
+      std::cout << "No leader" << std::endl;
     }
   }
 }


### PR DESCRIPTION
## Summary
- extend `GroundDroneInfo` with timestamp and online status
- track current leader in `GroundBaseStation`
- implement offline detection and dynamic leader election

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_6857652b37a48326b97af0796211a4c3