### PR TITLE
Fix offline leader status and tweak GUI window size

### DIFF
--- a/src/gyro_gui.cpp
+++ b/src/gyro_gui.cpp
@@ -182,7 +182,7 @@ private slots:
       droneTable_->setItem(row, 7, statusItem);
 
       QTableWidgetItem *leaderItem =
-          new QTableWidgetItem(d.leader ? "Yes" : "No");
+          new QTableWidgetItem((d.online && d.leader) ? "Yes" : "No");
       leaderItem->setTextAlignment(Qt::AlignCenter);
       droneTable_->setItem(row, 8, leaderItem);
 
@@ -205,7 +205,7 @@ private:
 int main(int argc, char **argv) {
   QApplication app(argc, argv);
   GyroServerWindow window;
-  window.setFixedSize(900, 400);
+  window.resize(1200, 400);
   window.show();
   return app.exec();
 }


### PR DESCRIPTION
## Summary
- show `Leader` as `No` when a drone is offline
- open the GUI window at a larger size and make it resizable

## Testing
- `cmake -S . -B build -DBUILD_GUI=ON`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_685768871454832680ebbfa64eb54e15