### PR TITLE
Add SYNC beacon support

### DIFF
--- a/include/packets.hpp
+++ b/include/packets.hpp
@@ -16,6 +16,7 @@ enum class PacketType : uint8_t {
   LEADER_ANNOUNCEMENT = 6,
   PERMISSION_TO_SEND = 7,
   LEADER_REQUEST = 8,
+  SYNC = 9,
 };
 // ==================== Constants ==================== //
 
@@ -78,6 +79,11 @@ struct PermissionToSendPacket {
   uint32_t timestamp;
 };
 
+struct SyncPacket {
+  PacketType type = PacketType::SYNC;
+  uint32_t timestamp;
+};
+
 struct LeaderRequestPacket {
   PacketType type = PacketType::LEADER_REQUEST;
   DroneIdType drone_id;
@@ -106,3 +112,5 @@ static_assert(sizeof(PermissionToSendPacket) == 6,
 
 static_assert(sizeof(LeaderRequestPacket) == 6,
               "LeaderRequestPacket size mismatch");
+
+static_assert(sizeof(SyncPacket) == 5, "SyncPacket size mismatch");

--- a/src/gyro_gui.cpp
+++ b/src/gyro_gui.cpp
@@ -9,9 +9,11 @@
 
 #include "radio.hpp"
 #include "sensor_utils.hpp"
+#include "packets.hpp"
 
 #include <chrono>
 #include <unordered_map>
+#include <ctime>
 
 #define TX_CE_PIN 27
 #define TX_CSN_PIN 0
@@ -88,6 +90,10 @@ public:
     QTimer *timer = new QTimer(this);
     connect(timer, &QTimer::timeout, this, &GyroServerWindow::pollRadio);
     timer->start(250);
+
+    QTimer *syncTimer = new QTimer(this);
+    connect(syncTimer, &QTimer::timeout, this, &GyroServerWindow::sendSync);
+    syncTimer->start(500);
   }
 
 private slots:
@@ -199,6 +205,12 @@ private slots:
 
       ++row;
     }
+  }
+
+  void sendSync() {
+    SyncPacket pkt{};
+    pkt.timestamp = static_cast<uint32_t>(std::time(nullptr));
+    txRadio_.send(&pkt, sizeof(pkt));
   }
 
 private:


### PR DESCRIPTION
## Summary
- add SYNC packet type with struct and size check
- periodically send SYNC packets from `gyro_gui`

## Testing
- `cmake -S . -B build -DBUILD_GUI=OFF`
- `cmake --build build`
- ❌ `cmake --build build` with `BUILD_GUI=ON` (fails: could not find Qt5)

------
https://chatgpt.com/codex/tasks/task_e_6857bb48292883268ad57df139c60100